### PR TITLE
Add image sizing with width and height config fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This card is quite simple so there are only a few options:
 | ---- | ---- | ------- | ----------- |
 | type | string | `custom:media-source-image-card` | **REQUIRED** |
 | image | string | | **REQUIRED** The path to the image in media source format. i.e: media-source://media_source/local/my_image.jpg |
+| width | string | '100%' | Image width |
+| height | string | '100%' | Image height |
 | entity_id | string | | The entity you want to toggle when card is clicked |
 | apply_grayscale | boolean | | If `true` applies a grayscale on the image when entity is `off` |
 | forced_refresh_interval | integer | | Number of seconds to force an image refresh |

--- a/media-source-image-card.js
+++ b/media-source-image-card.js
@@ -28,7 +28,10 @@ class MediaSourceImageCard extends HTMLElement {
 
             img {
                 display: block;
+                max-width: ${this.config.width ? this.config.width : '100%'};
+                max-height: ${this.config.height ? this.config.height : '100%'};
                 width: 100%;
+                height: 100%;
             }
 
             img.off {
@@ -127,15 +130,15 @@ class MediaSourceImageCard extends HTMLElement {
 
   renderContent() {
     this.getImageUrl(this.config.image)
-      .then(response => {
-          if (this.image != response.url) {
-            this.image = response.url;
-            if (response.url.indexOf('mp4') != -1 || response.url.indexOf('ogg') != -1 || response.url.indexOf('webm') != -1) {
-              this.content.innerHTML = `<video width="${this.config.video_options?.width || '320'}" height="${this.config.video_options?.height || '240'}" ${this.config.video_options?.show_controls ? 'controls' : ''} ${this.config.video_options?.loop ? 'loop' : ''} ${this.config.video_options?.autoplay ? 'autoplay' : ''} ${this.config.video_options?.muted ? 'muted' : ''} ${this.config.video_options?.type ? `type=${this.config.video_options?.type}`: ''}><source src="${response.url}" playsInLine></source></video>`;
-            } else {
-              this.content.innerHTML = `<img src=${response.url} class="${(this.config.entity_id && this.config.apply_grayscale) ? this._hass.states[this.config.entity_id].state : ''}">`;
-            }
-          }
+    .then(response => {
+      if (this.image != response.url) {
+        this.image = response.url;
+        if (response.url.indexOf('mp4') != -1 || response.url.indexOf('ogg') != -1 || response.url.indexOf('webm') != -1) {
+          this.content.innerHTML = `<video width="${this.config.video_options?.width || '320'}" height="${this.config.video_options?.height || '240'}" ${this.config.video_options?.show_controls ? 'controls' : ''} ${this.config.video_options?.loop ? 'loop' : ''} ${this.config.video_options?.autoplay ? 'autoplay' : ''} ${this.config.video_options?.muted ? 'muted' : ''} ${this.config.video_options?.type ? `type=${this.config.video_options?.type}`: ''}><source src="${response.url}" playsInLine></source></video>`;
+        } else {
+          this.content.innerHTML = `<img src=${response.url} class="${(this.config.entity_id && this.config.apply_grayscale) ? this._hass.states[this.config.entity_id].state : ''}">`;
+        }
+      }
       })
   }
 


### PR DESCRIPTION
Adds two new fields `width` and `height` that can be used to set the size of the image.

This example:

```yaml
type: custom:media-source-image-card
image: >-
  https://t4.ftcdn.net/jpg/01/43/23/83/360_F_143238306_lh0ap42wgot36y44WybfQpvsJB5A1CHc.jpg
width: 300px
height: 200px
```

would render as this:

![image](https://github.com/user-attachments/assets/0e9ece60-4aac-471e-b178-2de69239a0f4)

You can use any value that's css valid (100px, 100%, 10rem, 10em, etc.). And you may use `card_mod` or tweak your theme for it to look pretty :P

Closes #17 